### PR TITLE
Independent metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pip install keras-metrics
 The usage of the package is simple:
 ```py
 import keras
-import keras_metrics
+import keras_metrics as km
 
 model = models.Sequential()
 model.add(keras.layers.Dense(1, activation="sigmoid", input_dim=2))
@@ -26,27 +26,65 @@ model.add(keras.layers.Dense(1, activation="softmax"))
 
 model.compile(optimizer="sgd",
               loss="binary_crossentropy",
-              metrics=[keras_metrics.precision(), keras_metrics.recall()])
+              metrics=[km.binary_precision(), km.binary_recall()])
 ```
 
 Similar configuration for multi-label binary crossentropy:
 ```py
 import keras
-import keras_metrics
+import keras_metrics as km
 
 model = models.Sequential()
 model.add(keras.layers.Dense(1, activation="sigmoid", input_dim=2))
 model.add(keras.layers.Dense(2, activation="softmax"))
 
 # Calculate precision for the second label.
-precision = keras_metrics.precision(label=1)
+precision = km.binary_precision(label=1)
 
 # Calculate recall for the first label.
-recall = keras_metrics.recall(label=0)
+recall = km.recall(label=0)
 
 model.compile(optimizer="sgd",
               loss="binary_crossentropy",
               metrics=[precision, recall])
+```
+
+Keras metrics package also supports metrics for categorical crossentropy and
+sparse categorical crossentropy:
+```py
+import keras_metrics as km
+
+c_precision = km.categorical_precision()
+sc_precision = km.sparse_categorical_precision()
+
+# ...
+```
+
+## Tensorflow Keras
+
+Tensorflow library provides the ```keras``` package as parts of its API, in
+order to use ```keras_metrics``` with Tensorflow Keras, you are advised to
+perform model training with initialized global variables:
+```py
+import numpy as np
+import keras_metrics as km
+import tensorflow as tf
+import tensorflow.keras as keras
+
+model = keras.Sequential()
+model.add(keras.layers.Dense(1, activation="softmax"))
+model.compile(optimizer="sgd",
+              loss="binary_crossentropy",
+              metrics=[km.binary_true_positive()])
+
+x = np.array([[0], [1], [0], [1]])
+y = np.array([1, 0, 1, 0]
+
+# Wrap model.fit into the session with global
+# variables initialization.
+with tf.Session() as s:
+    s.run(tf.global_variables_initializer())
+    model.fit(x=x, y=y)
 ```
 
 [BuildStatus]: https://travis-ci.org/netrack/keras-metrics.svg?branch=master

--- a/keras_metrics/__init__.py
+++ b/keras_metrics/__init__.py
@@ -1,4 +1,63 @@
+from functools import partial
+from keras_metrics import metrics as m
+from keras_metrics import casts
+
+
 __version__ = "0.0.7"
 
 
-from keras_metrics.metrics import *
+def metric_fn(cls, cast_strategy):
+    def fn(label=0, **kwargs):
+        metric = cls(label=label, cast_strategy=cast_strategy, **kwargs)
+        metric.__name__ = "%s_%s" % (cast_strategy.__name__, cls.__name__)
+        return metric
+    return fn
+
+
+binary_metric = partial(
+    metric_fn, cast_strategy=casts.binary)
+
+
+categorical_metric = partial(
+    metric_fn, cast_strategy=casts.categorical)
+
+
+sparse_categorical_metric = partial(
+    metric_fn, cast_strategy=casts.sparse_categorical)
+
+
+binary_true_positive = binary_metric(m.true_positive)
+binary_true_negative = binary_metric(m.true_negative)
+binary_false_positive = binary_metric(m.false_positive)
+binary_false_negative = binary_metric(m.false_negative)
+binary_precision = binary_metric(m.precision)
+binary_recall = binary_metric(m.recall)
+binary_f1_score = binary_metric(m.f1_score)
+
+
+categorical_true_positive = categorical_metric(m.true_positive)
+categorical_true_negative = categorical_metric(m.true_negative)
+categorical_false_positive = categorical_metric(m.false_positive)
+categorical_false_negative = categorical_metric(m.false_negative)
+categorical_precision = categorical_metric(m.precision)
+categorical_recall = categorical_metric(m.recall)
+categorical_f1_score = categorical_metric(m.f1_score)
+
+
+sparse_categorical_true_positive = sparse_categorical_metric(m.true_positive)
+sparse_categorical_true_negative = sparse_categorical_metric(m.true_negative)
+sparse_categorical_false_positive = sparse_categorical_metric(m.false_positive)
+sparse_categorical_false_negative = sparse_categorical_metric(m.false_negative)
+sparse_categorical_precision = sparse_categorical_metric(m.precision)
+sparse_categorical_recall = sparse_categorical_metric(m.recall)
+sparse_categorical_f1_score = sparse_categorical_metric(m.f1_score)
+
+
+# For backward compatibility.
+true_positive = binary_true_positive
+true_negative = binary_true_negative
+false_positive = binary_false_positive
+false_negative = binary_false_negative
+precision = binary_precision
+recall = binary_recall
+f1_score = binary_f1_score

--- a/keras_metrics/casts.py
+++ b/keras_metrics/casts.py
@@ -1,0 +1,26 @@
+from keras import backend as K
+
+
+def binary(y_true, y_pred, dtype="int32", label=0):
+    return categorical(y_true, y_pred, dtype, label)
+
+
+def categorical(y_true, y_pred, dtype="int32", label=0):
+    column = slice(label, label+1)
+
+    y_true = y_true[..., column]
+    y_pred = y_pred[..., column]
+
+    y_true = K.cast(K.round(y_true), dtype)
+    y_pred = K.cast(K.round(y_pred), dtype)
+
+    return y_true, y_pred
+
+
+def sparse_categorical(y_true, y_pred, dtype="int32", label=0):
+    y_true = K.cast(K.equal(y_true, label), dtype=dtype)
+
+    y_pred = y_pred[..., slice(label, label+1)]
+    y_pred = K.cast(K.round(y_pred), dtype)
+
+    return y_true, y_pred

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,84 +1,120 @@
 import keras
 import keras.backend
-import keras_metrics
+import keras.utils
+import keras.regularizers
+import keras_metrics as km
 import itertools
 import numpy
 import tempfile
 import unittest
 
+from keras import backend as K
+
 
 class TestMetrics(unittest.TestCase):
 
-    def __init__(self, methodName, sparse=False):
-        super(TestMetrics, self).__init__(methodName=methodName)
-        self.sparse = sparse
+    binary_metrics = [
+        km.binary_true_positive,
+        km.binary_true_negative,
+        km.binary_false_positive,
+        km.binary_false_negative,
+        km.binary_precision,
+        km.binary_recall,
+        km.binary_f1_score,
+    ]
 
-    def setUp(self):
-        tp = keras_metrics.true_positive(sparse=self.sparse)
-        tn = keras_metrics.true_negative(sparse=self.sparse)
-        fp = keras_metrics.false_positive(sparse=self.sparse)
-        fn = keras_metrics.false_negative(sparse=self.sparse)
+    categorical_metrics = [
+        km.categorical_true_positive,
+        km.categorical_true_negative,
+        km.categorical_false_positive,
+        km.categorical_false_negative,
+        km.categorical_precision,
+        km.categorical_recall,
+        km.categorical_f1_score,
+    ]
 
-        precision = keras_metrics.precision(sparse=self.sparse)
-        recall = keras_metrics.recall(sparse=self.sparse)
-        f1 = keras_metrics.f1_score(sparse=self.sparse)
+    sparse_categorical_metrics = [
+        km.sparse_categorical_true_positive,
+        km.sparse_categorical_true_negative,
+        km.sparse_categorical_false_positive,
+        km.sparse_categorical_false_negative,
+        km.sparse_categorical_precision,
+        km.sparse_categorical_recall,
+        km.sparse_categorical_f1_score,
+    ]
 
-        self.model = keras.models.Sequential()
-        self.model.add(keras.layers.Activation(keras.backend.sin))
-        self.model.add(keras.layers.Activation(keras.backend.abs))
-
-        if self.sparse:
-            loss = "sparse_categorical_crossentropy"
-        else:
-            loss = "binary_crossentropy"
-
-        self.model.compile(optimizer="sgd",
-                           loss=loss,
-                           metrics=[tp, tn, fp, fn, precision, recall, f1])
-
-    def samples(self, n):
-        if self.sparse:
-            categories = 2
-            x = numpy.random.uniform(0, numpy.pi/2, (n, categories))
-            y = numpy.random.randint(categories, size=(n, 1))
-        else:
-            x = numpy.random.uniform(0, numpy.pi/2, (n, 1))
-            y = numpy.random.randint(2, size=(n, 1))
+    def create_binary_samples(self, n):
+        x = numpy.random.uniform(0, numpy.pi/2, (n, 1))
+        y = numpy.random.randint(2, size=(n, 1))
         return x, y
 
-    def test_save_load(self):
-        custom_objects = {
-            "true_positive": keras_metrics.true_positive(sparse=self.sparse),
-            "true_negative": keras_metrics.true_negative(sparse=self.sparse),
-            "false_positive": keras_metrics.false_positive(sparse=self.sparse),
-            "false_negative": keras_metrics.false_negative(sparse=self.sparse),
-            "precision": keras_metrics.precision(sparse=self.sparse),
-            "recall": keras_metrics.recall(sparse=self.sparse),
-            "f1_score": keras_metrics.f1_score(sparse=self.sparse),
-            "sin": keras.backend.sin,
-            "abs": keras.backend.abs,
-        }
+    def create_categorical_samples(self, n):
+        x, y = self.create_binary_samples(n)
+        return x, keras.utils.to_categorical(y)
 
-        x, y = self.samples(100)
-        self.model.fit(x, y, epochs=10)
+    def create_metrics(self, metrics_fns):
+        return list(map(lambda m: m(), metrics_fns))
+
+    def create_model(self, outputs, loss, metrics_fns):
+        model = keras.models.Sequential()
+        model.add(keras.layers.Activation(keras.backend.sin))
+        model.add(keras.layers.Activation(keras.backend.abs))
+        model.add(keras.layers.Lambda(lambda x: K.concatenate([x]*outputs)))
+        model.compile(optimizer="sgd",
+                      loss=loss,
+                      metrics=self.create_metrics(metrics_fns))
+        return model
+
+    def assert_save_load(self, model, metrics_fns, samples_fn):
+        metrics = [m() for m in metrics_fns]
+
+        custom_objects = {m.__name__: m for m in metrics}
+        custom_objects["sin"] = keras.backend.sin
+        custom_objects["abs"] = keras.backend.abs
+
+        x, y = samples_fn(100)
+        model.fit(x, y, epochs=10)
 
         with tempfile.NamedTemporaryFile() as file:
-            self.model.save(file.name, overwrite=True)
-            model = keras.models.load_model(file.name, custom_objects=custom_objects)
+            model.save(file.name, overwrite=True)
 
-            expected = self.model.evaluate(x, y)[1:]
-            received = model.evaluate(x, y)[1:]
+            loaded_model = keras.models.load_model(
+                file.name, custom_objects=custom_objects)
+
+            expected = model.evaluate(x, y)[1:]
+            received = loaded_model.evaluate(x, y)[1:]
 
             self.assertEqual(expected, received)
 
-    def test_metrics(self):
+    def test_save_load_binary_metrics(self):
+        model = self.create_model(1, "binary_crossentropy",
+                                  self.binary_metrics)
+        self.assert_save_load(model,
+                              self.binary_metrics,
+                              self.create_binary_samples)
+
+    def test_save_load_categorical_metrics(self):
+        model = self.create_model(2, "categorical_crossentropy",
+                                  self.categorical_metrics)
+        self.assert_save_load(model,
+                              self.categorical_metrics,
+                              self.create_categorical_samples)
+
+    def test_save_load_sparse_categorical_metrics(self):
+        model = self.create_model(2, "sparse_categorical_crossentropy",
+                                  self.sparse_categorical_metrics)
+        self.assert_save_load(model,
+                              self.sparse_categorical_metrics,
+                              self.create_binary_samples)
+
+    def assert_metrics(self, model, samples_fn):
         samples = 10000
         batch_size = 100
 
-        x, y = self.samples(samples)
+        x, y = samples_fn(samples)
 
-        self.model.fit(x, y, epochs=10, batch_size=batch_size)
-        metrics = self.model.evaluate(x, y, batch_size=batch_size)[1:]
+        model.fit(x, y, epochs=10, batch_size=batch_size)
+        metrics = model.evaluate(x, y, batch_size=batch_size)[1:]
 
         metrics = list(map(float, metrics))
 
@@ -110,17 +146,21 @@ class TestMetrics(unittest.TestCase):
         self.assertAlmostEqual(expected_recall, recall, places=places)
         self.assertAlmostEqual(expected_f1, f1, places=places)
 
+    def test_binary_metrics(self):
+        model = self.create_model(1, "binary_crossentropy",
+                                  self.binary_metrics)
+        self.assert_metrics(model, self.create_binary_samples)
 
-def suite():
-    s = unittest.TestSuite()
-    s.addTests(TestMetrics(methodName=method, sparse=sparse)
-               for method in unittest.defaultTestLoader.getTestCaseNames(TestMetrics)
-               for sparse in (False, True))
-    return s
+    def test_categorical_metrics(self):
+        model = self.create_model(2, "categorical_crossentropy",
+                                  self.categorical_metrics)
+        self.assert_metrics(model, self.create_categorical_samples)
+
+    def test_sparse_categorical_metrics(self):
+        model = self.create_model(2, "sparse_categorical_crossentropy",
+                                  self.sparse_categorical_metrics)
+        self.assert_metrics(model, self.create_binary_samples)
 
 
 if __name__ == "__main__":
-    import sys
-    result = unittest.TextTestRunner().run(suite())
-    sys.exit(not result.wasSuccessful())
-    # unittest.main()
+    unittest.main()


### PR DESCRIPTION
This patch separates metrics by the task they target to measure.
So now, there are tree types of metrics:
 - binary metrics
 - categorical metrics
 - sparse categorical metrics

To preserve backward compatibility with the older code, old names
"precision", "recall", etc. refer to the "binary_precision",
"binary_recall", etc. respectively.

These changes require to bump major version of the package.