### PR TITLE
Add deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Keras Metrics
 
+## Deprecation Warning
+
+Since Keras version `2.3.0`, it provides all metrics available in this package.
+It's preferrable to use metrics from the original Keras package.
+
+This package will be maintained for older version of Keras (`<2.3.0`).
+
 [![Build Status][BuildStatus]](https://travis-ci.org/netrack/keras-metrics)
 
 This package provides metrics for evaluation of Keras classification models.

--- a/keras_metrics/__init__.py
+++ b/keras_metrics/__init__.py
@@ -3,7 +3,7 @@ from keras_metrics import metrics as m
 from keras_metrics import casts
 
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 
 def metric_fn(cls, cast_strategy):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Keras>=2.1.6
+Keras>=2.1.5,<2.3.0
 tensorflow>=1.8.0,<2.0.0
 scikit-learn>=0.20.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Keras>=2.1.6,<2.2.5
-tensorflow>=1.8.0
+Keras>=2.1.6
+tensorflow>=1.8.0,<2.0.0
 scikit-learn>=0.20.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Keras>=2.1.6,<2.3.0
+Keras>=2.1.6,<2.2.5
 tensorflow>=1.8.0
 scikit-learn>=0.20.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Keras>=2.1.6
+Keras>=2.1.6,<2.3.0
 tensorflow>=1.8.0
 scikit-learn>=0.20.2

--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,5 @@ setuptools.setup(
     keywords="keras metrics evaluation",
 
     packages=setuptools.find_packages(exclude=["tests"]),
-    install_requires=["Keras>=2.1.5,<2.3.0"],
+    install_requires=["Keras>=2.1.5"],
 )

--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,5 @@ setuptools.setup(
     keywords="keras metrics evaluation",
 
     packages=setuptools.find_packages(exclude=["tests"]),
-    install_requires=["Keras>=2.1.5"],
+    install_requires=["Keras>=2.1.5,<2.3.0"],
 )


### PR DESCRIPTION
This patch adds deprecation warning (since Keras 2.3.0 already provides
all necessary metrics).